### PR TITLE
빌드를 위한 Dockerfile 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-jdk-alpine
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","-Dspring.profiles.active=prod","/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -41,3 +41,7 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+jar {
+	enabled = false
+}


### PR DESCRIPTION
Docker 이미지를 생성하기 위한 Dockerfile 추가
build/libs에 위치한 jar파일을 실행시켜주는 도커 빌드파일

- OpenJDK 17 버전을 기반으로하여 Spring 애플리케이션을 실행하도록 함
- 애플리케이션의 JAR 파일을 도커 이미지로 복사하고, 8080 포트로 매핑
- 실행시 "prod" 프로파일을 사용하여 애플리케이션 실행
  - prod 프로파일은 지금 없어도 빌드시에 문제x