### PR TITLE
업로드시 한글 인코딩 오류 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 	// aws s3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'commons-io:commons-io:2.8.0'
+	implementation platform('com.amazonaws:aws-java-sdk-bom:1.11.1000')
+	implementation 'com.amazonaws:aws-java-sdk-s3'
 
 }
 

--- a/src/main/java/com/kl/grooveo/boundedContext/library/controller/FileUploadController.java
+++ b/src/main/java/com/kl/grooveo/boundedContext/library/controller/FileUploadController.java
@@ -68,7 +68,6 @@ public class FileUploadController {
             String title = URLEncoder.encode(soundTrackForm.getTitle(), StandardCharsets.UTF_8);
             String description = URLEncoder.encode(soundTrackForm.getDescription(), StandardCharsets.UTF_8);
 
-
             ObjectMetadata albumCoverMetadata = new ObjectMetadata();
             albumCoverMetadata.setContentType(soundTrackForm.getAlbumCover().getContentType());
             albumCoverMetadata.setContentLength(soundTrackForm.getAlbumCover().getSize());

--- a/src/main/java/com/kl/grooveo/boundedContext/library/controller/FileUploadController.java
+++ b/src/main/java/com/kl/grooveo/boundedContext/library/controller/FileUploadController.java
@@ -19,10 +19,10 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -65,17 +65,21 @@ public class FileUploadController {
             String soundName = UUID.randomUUID().toString() + "." + soundExtension;
             String soundUrl = "https://s3." + region + ".amazonaws.com/" + bucket + "/sound/" + soundName;
 
+            String title = URLEncoder.encode(soundTrackForm.getTitle(), StandardCharsets.UTF_8);
+            String description = URLEncoder.encode(soundTrackForm.getDescription(), StandardCharsets.UTF_8);
+
+
             ObjectMetadata albumCoverMetadata = new ObjectMetadata();
             albumCoverMetadata.setContentType(soundTrackForm.getAlbumCover().getContentType());
             albumCoverMetadata.setContentLength(soundTrackForm.getAlbumCover().getSize());
-            albumCoverMetadata.addUserMetadata("title", soundTrackForm.getTitle());
-            albumCoverMetadata.addUserMetadata("description", soundTrackForm.getDescription());
+            albumCoverMetadata.addUserMetadata("title", title);
+            albumCoverMetadata.addUserMetadata("description", description);
 
             ObjectMetadata soundMetadata = new ObjectMetadata();
             soundMetadata.setContentType(soundTrackForm.getSoundFile().getContentType());
             soundMetadata.setContentLength(soundTrackForm.getSoundFile().getSize());
-            soundMetadata.addUserMetadata("title", soundTrackForm.getTitle());
-            soundMetadata.addUserMetadata("description", soundTrackForm.getDescription());
+            soundMetadata.addUserMetadata("title", title);
+            soundMetadata.addUserMetadata("description", description);
 
             amazonS3Client.putObject(new PutObjectRequest(bucket, "albumCover/" + albumCoverName, soundTrackForm.getAlbumCover().getInputStream(), albumCoverMetadata));
             amazonS3Client.putObject(new PutObjectRequest(bucket, "sound/" + soundName, soundTrackForm.getSoundFile().getInputStream(), soundMetadata));

--- a/src/main/java/com/kl/grooveo/boundedContext/library/controller/SoundTrackController.java
+++ b/src/main/java/com/kl/grooveo/boundedContext/library/controller/SoundTrackController.java
@@ -28,6 +28,8 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 
@@ -165,17 +167,20 @@ public class SoundTrackController {
             String soundName = UUID.randomUUID().toString() + "." + soundExtension;
             String soundUrl = "https://s3." + region + ".amazonaws.com/" + bucket + "/sound/" + soundName;
 
+            String title = URLEncoder.encode(soundTrackForm.getTitle(), StandardCharsets.UTF_8);
+            String description = URLEncoder.encode(soundTrackForm.getDescription(), StandardCharsets.UTF_8);
+
             ObjectMetadata albumCoverMetadata = new ObjectMetadata();
             albumCoverMetadata.setContentType(soundTrackForm.getAlbumCover().getContentType());
             albumCoverMetadata.setContentLength(soundTrackForm.getAlbumCover().getSize());
-            albumCoverMetadata.addUserMetadata("title", soundTrackForm.getTitle());
-            albumCoverMetadata.addUserMetadata("description", soundTrackForm.getDescription());
+            albumCoverMetadata.addUserMetadata("title", title);
+            albumCoverMetadata.addUserMetadata("description", description);
 
             ObjectMetadata soundMetadata = new ObjectMetadata();
             soundMetadata.setContentType(soundTrackForm.getSoundFile().getContentType());
             soundMetadata.setContentLength(soundTrackForm.getSoundFile().getSize());
-            soundMetadata.addUserMetadata("title", soundTrackForm.getTitle());
-            soundMetadata.addUserMetadata("description", soundTrackForm.getDescription());
+            soundMetadata.addUserMetadata("title", title);
+            soundMetadata.addUserMetadata("description", description);
 
             amazonS3Client.putObject(new PutObjectRequest(bucket, "albumCover/" + albumCoverName, soundTrackForm.getAlbumCover().getInputStream(), albumCoverMetadata));
             amazonS3Client.putObject(new PutObjectRequest(bucket, "sound/" + soundName, soundTrackForm.getSoundFile().getInputStream(), soundMetadata));


### PR DESCRIPTION
## 문제
업로드시 음원명과 설명에 한글로 입력하면 등록이 안되는 버그 발생


### 원인
S3의 사용자 메타데이터(User Metadata)와 관련이 있는 것으로 추정
AWS S3의 사용자 정의 메타데이터는 ASCII 문자만을 지원한다. 따라서, 아래의 두 줄에서 한글 문자열을 사용자 메타데이터로 설정하려고 해서 문제가 발생한 것 !

`soundTrackForm.getTitle()`과 `soundTrackForm.getDescription()` 메서드가 한글 문자열을 반환하는 경우, S3의 사용자 메타데이터에 추가하는 동작에서 오류가 발생한다.

### 해결
- `soundTrackForm.getTitle()`과 `soundTrackForm.getDescription()` 메서드가 반환하는 문자열을 URL 인코딩하여 사용자 메타데이터에 추가
- URL 인코딩된 문자열은 ASCII 문자만을 포함하므로, S3의 사용자 메타데이터에 추가

이 방법으로 한글 문자열을 사용자 메타데이터에 추가하는 문제를 해결